### PR TITLE
Change img hover effect to use scss syntax

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -104,9 +104,7 @@ $box-general-shadow: 10px 10px rgb(197, 197, 197);
     background-size: cover;
     border-radius: 20px;
     transition: 0.7s;
-  }
-
-  .img:hover {
+  &:hover {
     transform: rotate(-3deg);
   }
 }


### PR DESCRIPTION
```
.img {
    background: url(../images/shop-bg.svg);
    background-attachment: fixed;
    background-repeat: no-repeat;
    background-size: cover;
    border-radius: 20px;
    transition: 0.7s;
  &:hover {
    transform: rotate(-3deg);
  }
}
```
This is the way you write things like this in scss